### PR TITLE
Add Jacob Node module and AnnabanOS-Lite kernel with sandboxed execution

### DIFF
--- a/annabanos_lite/__init__.py
+++ b/annabanos_lite/__init__.py
@@ -1,0 +1,3 @@
+from .kernel import AnnabanOSLiteKernel, ModuleExecutionRecord, SandboxedModule
+
+__all__ = ["AnnabanOSLiteKernel", "ModuleExecutionRecord", "SandboxedModule"]

--- a/annabanos_lite/kernel.py
+++ b/annabanos_lite/kernel.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import copy
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Protocol
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+
+
+class SandboxedModule(Protocol):
+    """Protocol for sandboxed AnnabanOS-Lite modules."""
+
+    name: str
+
+    def run(self, shared_state: Dict[str, Any]) -> Dict[str, Any]:
+        ...
+
+
+@dataclass
+class ModuleExecutionRecord:
+    module_name: str
+    timestamp: str
+    status: str
+    alerts: List[str] = field(default_factory=list)
+    events: List[Dict[str, Any]] = field(default_factory=list)
+
+
+class AnnabanOSLiteKernel:
+    """Minimal modular kernel with shared state and sandboxed module execution."""
+
+    def __init__(self) -> None:
+        self.shared_state: Dict[str, Any] = {
+            "jacob_node": {
+                "identity": {
+                    "node_type": "personal_architect_node",
+                    "public_lattice_isolation": True,
+                    "ftdt_principal_usd": 6_692_000_000_000.0,
+                    "ftdt_principal_touched": False,
+                },
+                "funding": {},
+                "liquidity": {},
+                "signals": {},
+                "milestones": [],
+                "alerts": [],
+                "logs": [],
+            }
+        }
+        self.execution_log: List[ModuleExecutionRecord] = []
+
+    def register_state(self, key: str, value: Dict[str, Any]) -> None:
+        self.shared_state.setdefault(key, value)
+
+    def execute_module(self, module: SandboxedModule) -> Dict[str, Any]:
+        sandbox_view = copy.deepcopy(self.shared_state)
+        result = module.run(sandbox_view)
+
+        allowed_keys = {"jacob_node"}
+        for key in allowed_keys:
+            if key in sandbox_view:
+                self.shared_state[key] = sandbox_view[key]
+
+        record = ModuleExecutionRecord(
+            module_name=module.name,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            status=result.get("status", "ok"),
+            alerts=result.get("alerts", []),
+            events=result.get("events", []),
+        )
+        self.execution_log.append(record)
+        logger.info("Executed module %s with status %s", module.name, record.status)
+        return result

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,0 +1,3 @@
+from .jacob_node_module import JacobNodeModule
+
+__all__ = ["JacobNodeModule"]

--- a/modules/jacob_node_module.py
+++ b/modules/jacob_node_module.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+
+@dataclass
+class JacobNodeModule:
+    """Sandboxed personal-node module for Jacob sovereignty and legacy project flows."""
+
+    nasa_award_id: str = "NASA STMDA-AG-2026-007"
+    nasa_award_total_usd: float = 2_600_000.0
+    nasa_drawdown_usd: float = 420_000.0
+    monthly_burn_rate_usd: float = 95_000.0
+    ip_royalties_usd: float = 125_000.0
+    passive_inflows_usd: float = 210_000.0
+    cooperative_liquidity_usd: float = 4_200_000.0
+    ftdt_yield_signal_usd: float = 18_500_000.0
+    name: str = field(default="jacob_node_module", init=False)
+
+    def run(self, shared_state: Dict[str, Any]) -> Dict[str, Any]:
+        node = shared_state.setdefault("jacob_node", {})
+        identity = node.setdefault("identity", {})
+        identity.update(
+            {
+                "node_type": "personal_architect_node",
+                "public_lattice_isolation": True,
+                "ftdt_principal_usd": 6_692_000_000_000.0,
+                "ftdt_principal_touched": False,
+            }
+        )
+
+        burn_coverage_months = round(
+            (self.cooperative_liquidity_usd + self.ip_royalties_usd + self.passive_inflows_usd)
+            / self.monthly_burn_rate_usd,
+            2,
+        )
+        drawdown_remaining = self.nasa_award_total_usd - self.nasa_drawdown_usd
+        drawdown_ratio = round(self.nasa_drawdown_usd / self.nasa_award_total_usd, 4)
+        self_sustaining = (self.ip_royalties_usd + self.passive_inflows_usd) >= self.monthly_burn_rate_usd
+
+        funding = node.setdefault("funding", {})
+        funding.update(
+            {
+                "award_id": self.nasa_award_id,
+                "award_total_usd": self.nasa_award_total_usd,
+                "drawdown_usd": self.nasa_drawdown_usd,
+                "drawdown_remaining_usd": drawdown_remaining,
+                "drawdown_ratio": drawdown_ratio,
+                "burn_rate_usd_per_month": self.monthly_burn_rate_usd,
+                "burn_coverage_months": burn_coverage_months,
+            }
+        )
+
+        liquidity = node.setdefault("liquidity", {})
+        liquidity.update(
+            {
+                "cooperative_liquidity_usd": self.cooperative_liquidity_usd,
+                "ip_royalties_usd": self.ip_royalties_usd,
+                "passive_inflows_usd": self.passive_inflows_usd,
+                "self_sustaining_threshold_reached": self_sustaining,
+            }
+        )
+
+        signals = node.setdefault("signals", {})
+        signals.update(
+            {
+                "ftdt_principal_usd": 6_692_000_000_000.0,
+                "ftdt_principal_touched": False,
+                "ftdt_yield_signal_usd": self.ftdt_yield_signal_usd,
+                "allocation_mode": "yield_signal_only",
+                "personal_node_only": True,
+            }
+        )
+
+        timestamp = datetime.now(timezone.utc).isoformat()
+        milestones = [
+            {
+                "id": "repair-demo",
+                "title": "/repair demo readiness",
+                "status": "scheduled",
+                "timestamp": timestamp,
+                "details": "Legacy repair flow staged under personal node governance.",
+            },
+            {
+                "id": "planetary-pilot",
+                "title": "Planetary Pilot initialization",
+                "status": "initiated",
+                "timestamp": timestamp,
+                "details": "Planetary Pilot lifecycle bootstrapped for orbital payload tracking.",
+            },
+        ]
+        node["milestones"] = milestones
+
+        alerts: List[str] = []
+        if self_sustaining:
+            alerts.append("Self-sustaining threshold reached via royalties and passive inflows.")
+        alerts.append(
+            f"FTDT yield allocation signaling active at ${self.ftdt_yield_signal_usd:,.2f} with principal untouched."
+        )
+        alerts.append("Legacy project initialization triggered for /repair demo and Planetary Pilot.")
+        node["alerts"] = alerts
+
+        logs = node.setdefault("logs", [])
+        logs.extend(
+            [
+                f"[{timestamp}] NASA drawdown: ${self.nasa_drawdown_usd:,.2f} used against ${self.monthly_burn_rate_usd:,.2f}/month burn.",
+                f"[{timestamp}] Royalties + passive inflows: ${self.ip_royalties_usd + self.passive_inflows_usd:,.2f}.",
+                f"[{timestamp}] Milestones generated: /repair demo, Planetary Pilot.",
+            ]
+        )
+
+        return {
+            "status": "ok",
+            "alerts": alerts,
+            "events": milestones,
+            "jacob_node": node,
+        }

--- a/tests/test_jacob_node_module.py
+++ b/tests/test_jacob_node_module.py
@@ -1,0 +1,34 @@
+import unittest
+
+from annabanos_lite.kernel import AnnabanOSLiteKernel
+from modules.jacob_node_module import JacobNodeModule
+
+
+class JacobNodeModuleTests(unittest.TestCase):
+    def test_jacob_node_state_updates_and_preserves_principal(self) -> None:
+        kernel = AnnabanOSLiteKernel()
+        module = JacobNodeModule(
+            nasa_drawdown_usd=500_000.0,
+            monthly_burn_rate_usd=100_000.0,
+            ip_royalties_usd=120_000.0,
+            passive_inflows_usd=90_000.0,
+        )
+
+        result = kernel.execute_module(module)
+        jacob_node = kernel.shared_state["jacob_node"]
+
+        self.assertEqual(result["status"], "ok")
+        self.assertEqual(jacob_node["funding"]["award_id"], "NASA STMDA-AG-2026-007")
+        self.assertEqual(jacob_node["funding"]["drawdown_usd"], 500_000.0)
+        self.assertEqual(jacob_node["funding"]["drawdown_remaining_usd"], 2_100_000.0)
+        self.assertTrue(jacob_node["liquidity"]["self_sustaining_threshold_reached"])
+        self.assertFalse(jacob_node["signals"]["ftdt_principal_touched"])
+        self.assertEqual(jacob_node["signals"]["allocation_mode"], "yield_signal_only")
+        self.assertEqual(len(jacob_node["milestones"]), 2)
+        self.assertIn("Self-sustaining threshold reached", jacob_node["alerts"][0])
+        self.assertTrue(any("NASA drawdown" in entry for entry in jacob_node["logs"]))
+        self.assertEqual(kernel.execution_log[-1].module_name, "jacob_node_module")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Represent the Jacob Node (personal architect node) in the kernel `shared_state` to track NASA award drawdown, personal liquidity, IP royalties, and legacy project flows. 
- Expose FTDT yield signals while ensuring the $6.692T FTDT principal remains untouched and personal node state is separated from any public lattice. 
- Provide a minimal, sandboxed module execution host so modules can safely update `kernel.shared_state["jacob_node"]` without breaking existing interfaces. 

### Description
- Added `annabanos_lite/kernel.py` implementing `AnnabanOSLiteKernel` with a deep-copied sandbox view for module execution and a controlled sync that only writes back the `jacob_node` key. 
- Added `modules/jacob_node_module.py` implementing `JacobNodeModule` which computes burn-coverage, drawdown remaining/ratio, self-sustaining threshold, FTDT yield signaling (principal untouched), generates `/repair demo` and `Planetary Pilot` milestones, and emits simulated alerts and logs. 
- Added package exports in `annabanos_lite/__init__.py` and `modules/__init__.py` so the kernel and module can be imported without changing existing code. 
- Added `tests/test_jacob_node_module.py` unit test that runs the module via the kernel and asserts funding/liquidity/signals/milestones/alerts are updated and that the FTDT principal remains untouched. 

### Testing
- Ran `python -m unittest tests.test_jacob_node_module` and the test passed. 
- Executed a manual simulation of `AnnabanOSLiteKernel().execute_module(JacobNodeModule())` to print the generated alerts and logs and verified drawdown, royalties, milestone triggers, and FTDT principal signaling behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb885a98288323b9ae98f0ec31d20d)