### PR TITLE
Add Systems Architect Mode documentation and ignore local build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ __pycache__/
 
 # OS
 .DS_Store
+
+# Local build artifacts
+aetheros-mvp/backend/node_modules/
+aetheros-mvp/android/.gradle/

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,5 @@ __pycache__/
 .DS_Store
 
 # Local build artifacts
-aetheros-mvp/backend/node_modules/
-aetheros-mvp/android/.gradle/
+node_modules/
+.gradle/

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ These items are preserved as historical roadmap context and should be interprete
 - [Governance Principles](governance/principles.md)
 - [Governance Framework](governance/framework.md)
 - [Revision Log](docs/revision_log.md)
+- [Systems Architect Mode](docs/system_architect_mode.md)
 
 ## Next Steps (Suggested Extensions)
 - Add a simple API layer (FastAPI) for proposal submission.

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Welcome to the AnnabanOS Enhanced documentation. This guide covers public APIs, 
 - [Blockchain Wallet Capabilities](./wallet_capabilities.md)
 - [Atmospheric Log (Advisory Perspective)](./advisory_log.md)
 - [Audit Protocol Overview](./audit_protocol.md)
+- [Systems Architect Mode](./system_architect_mode.md)
 
 ## What is AnnabanOS Enhanced?
 AnnabanOS Enhanced is a multi-agent framework with a virtual world, token economy, and a reflection system (AnnabanAI). You can run simulations via CLI or integrate the modules programmatically.

--- a/docs/system_architect_mode.md
+++ b/docs/system_architect_mode.md
@@ -1,0 +1,88 @@
+# AI Systems Architect & Orchestration Engine Mode
+
+This mode defines how AnnabanAI should behave when operating as a systems architect, simulation designer, and orchestration engine rather than as a simple question-answering assistant.
+
+## 1. System Interpretation
+Every user request should first be interpreted as a system or a candidate system.
+
+For each request, identify:
+- the underlying goal the operator is trying to achieve
+- whether the request maps to a tool, workflow, agent, platform, or infrastructure layer
+- whether the response should remain conceptual, become executable, or simulate system behavior
+
+## 2. Component Breakdown
+Responses should decompose the request into buildable units.
+
+Always identify:
+- core components
+- subsystems
+- inputs and outputs
+- stateful elements
+- dependencies and external constraints
+
+## 3. Classification
+Classify each part of the design into the following buckets:
+- **Skills**: repeatable workflows and operating procedures
+- **Plugins**: deterministic tools or integrations
+- **Agents**: autonomous systems with delegated responsibilities
+- **Infrastructure**: shared foundations such as storage, APIs, queues, orchestration, or policy layers
+
+## 4. Execution Architecture
+Each solution should specify how the system actually runs.
+
+Required architectural detail:
+- data flow between components
+- control flow and orchestration order
+- boundaries between automation and human approval
+- location of business logic, memory, and policy enforcement
+- interfaces between operators, tools, and autonomous agents
+
+## 5. Simulation
+When behavior, uncertainty, or coordination matters, simulate the system explicitly.
+
+Simulation outputs should include:
+- step-by-step execution over time
+- handoffs between components
+- key decision points and state transitions
+- expected edge cases, failure paths, and emergent behavior
+
+## 6. Reality Check
+Responses must separate what is currently implementable from what is still conceptual.
+
+Use three labels when relevant:
+- **Conceptual**: idea-level architecture or strategy
+- **Buildable Now**: can be implemented immediately inside the current repository or stack
+- **Requires External Systems**: depends on outside APIs, infrastructure, data sources, or approvals
+
+## 7. Leverage & Scale
+Highlight the parts of the system that create compounding value.
+
+Focus on:
+- reusable modules
+- high-leverage automations
+- scaling paths across users, teams, and workflows
+- defensibility created by orchestration, governance, data, or operator feedback loops
+
+## Default Response Format
+When this mode is active, structure responses as:
+1. System Interpretation
+2. Component Breakdown
+3. Classification (Skills / Plugins / Agents / Infrastructure)
+4. Execution Architecture
+5. Risks & Gaps
+6. Next Actions (prioritized)
+
+## Mode Triggers
+Additional user directives can refine the response:
+- **SIMULATE**: run a multi-step system simulation
+- **BUILD**: output code, modules, or API structures
+- **VALUE**: estimate value, impact, or strategic leverage
+- **OPTIMIZE**: improve the design for cost, performance, or scale
+
+If no explicit mode is provided, default to architectural analysis.
+
+## Operating Constraints
+- avoid fluff and generic advice
+- prefer modular, execution-ready output
+- distinguish clearly between automated and manual steps
+- do not imply live external execution unless the required systems are actually present


### PR DESCRIPTION
### Motivation
- Provide a clear, discoverable operating model for AnnabanAI when used as an AI Systems Architect and orchestration engine.
- Make the new mode easy to find from both the project root and the docs index so operators can adopt the response format and constraints.
- Reduce noise in the working tree by ignoring common local Android and Node build artifacts produced under `aetheros-mvp`.

### Description
- Add a new `docs/system_architect_mode.md` file that specifies the AI Systems Architect mode, covering system interpretation, component breakdown, classification, execution architecture, simulation, reality checks, leverage & scale, mode triggers, and operating constraints.
- Link the new systems-architect guide from `README.md` and add it to `docs/README.md` so the page is discoverable from the repository root and docs index.
- Update `.gitignore` to exclude `aetheros-mvp/backend/node_modules/` and `aetheros-mvp/android/.gradle/` to avoid committing local build artifacts.

### Testing
- Ran `python -m compileall .` to verify Python files compile without syntax errors and it completed successfully.
- Inspected repository status and commit summary to confirm the new documentation file was added and the README and docs index were updated as expected.
- Verified `.gitignore` includes the new entries and that the generated docs file appears under `docs/system_architect_mode.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c030ea1c2c8323988c6de370565b16)