### PR TITLE
Add AnnabanOS governance-first Grok prototype and whitepaper

### DIFF
--- a/annabanos/.env.example
+++ b/annabanos/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to .env and set your xAI API key.
+XAI_API_KEY=your_xai_api_key_here

--- a/annabanos/README.md
+++ b/annabanos/README.md
@@ -1,0 +1,71 @@
+# AnnabanOS
+
+AnnabanOS is a governance-first AI prototype that wraps the xAI Grok API with a policy enforcement layer, human approval gate, and append-only audit ledger.
+
+## Features
+
+- xAI Grok integration via OpenAI-compatible endpoint (`https://api.x.ai/v1`)
+- Governance layer (`AnnabanGovernance`) for policy checks
+- High-risk action detection (`deploy`, `execute`, `run`, `activate`)
+- Human-in-the-loop gating requiring approval from **Jacob Kinnaird**
+- JSONL ledger for full interaction auditability
+- Dictionary-based tool-calling with `verify_origin`
+- Dual-agent example (Planner + Oversight)
+
+## Repository Layout
+
+```text
+annabanos/
+├── README.md
+├── requirements.txt
+├── .env.example
+├── main.py
+├── annaban/
+│   ├── __init__.py
+│   ├── grok_client.py
+│   ├── governance.py
+│   ├── tools.py
+│   └── ledger.py
+├── examples/
+│   └── dual_agent_demo.py
+├── logs/
+│   └── governance_ledger.jsonl
+└── docs/
+    └── AnnabanAI_Whitepaper.md
+```
+
+## Quick Start
+
+1. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Configure environment:
+
+   ```bash
+   cp .env.example .env
+   # edit .env and set XAI_API_KEY
+   ```
+
+3. Run CLI:
+
+   ```bash
+   python main.py
+   ```
+
+4. Run dual-agent demo:
+
+   ```bash
+   python examples/dual_agent_demo.py
+   ```
+
+## Governance Flow
+
+1. User prompt enters `AnnabanGovernance`.
+2. Prompt is checked for high-risk keywords.
+3. If flagged, the system returns:
+   `⚠️ HUMAN APPROVAL REQUIRED FROM Jacob Kinnaird BEFORE EXECUTION`
+4. If not flagged, the prompt is sent to Grok (`grok-4.20`).
+5. Every interaction is written to `logs/governance_ledger.jsonl`.

--- a/annabanos/annaban/__init__.py
+++ b/annabanos/annaban/__init__.py
@@ -1,0 +1,7 @@
+"""AnnabanOS core package."""
+
+from .governance import AnnabanGovernance
+from .grok_client import GrokClient
+from .ledger import GovernanceLedger
+
+__all__ = ["AnnabanGovernance", "GrokClient", "GovernanceLedger"]

--- a/annabanos/annaban/governance.py
+++ b/annabanos/annaban/governance.py
@@ -1,0 +1,47 @@
+"""Governance layer for policy checks, approval gating, and ledgering."""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+from .grok_client import GrokClient
+from .ledger import GovernanceLedger
+
+
+class AnnabanGovernance:
+    """Policy enforcement wrapper around Grok client calls."""
+
+    HIGH_RISK_KEYWORDS = ("deploy", "execute", "run", "activate")
+    APPROVAL_MESSAGE = "⚠️ HUMAN APPROVAL REQUIRED FROM Jacob Kinnaird BEFORE EXECUTION"
+
+    def __init__(self, grok_client: GrokClient, ledger: Optional[GovernanceLedger] = None) -> None:
+        self.grok_client = grok_client
+        self.ledger = ledger or GovernanceLedger()
+
+    def _is_high_risk(self, prompt: str) -> bool:
+        pattern = r"\b(" + "|".join(map(re.escape, self.HIGH_RISK_KEYWORDS)) + r")\b"
+        return bool(re.search(pattern, prompt, flags=re.IGNORECASE))
+
+    def process(self, prompt: str, system_prompt: str = "You are a helpful assistant.") -> str:
+        """Run policy checks, optionally gate execution, and log all outcomes."""
+        risk_flagged = self._is_high_risk(prompt)
+
+        if risk_flagged:
+            response = self.APPROVAL_MESSAGE
+            self.ledger.append(
+                prompt=prompt,
+                response=response,
+                risk_flagged=True,
+                requires_approval=True,
+            )
+            return response
+
+        response = self.grok_client.call(prompt=prompt, system_prompt=system_prompt)
+        self.ledger.append(
+            prompt=prompt,
+            response=response,
+            risk_flagged=False,
+            requires_approval=False,
+        )
+        return response

--- a/annabanos/annaban/grok_client.py
+++ b/annabanos/annaban/grok_client.py
@@ -1,0 +1,22 @@
+"""Client wrapper for the xAI Grok API using the OpenAI-compatible SDK."""
+
+
+class GrokClient:
+    """Thin wrapper around xAI's OpenAI-compatible endpoint."""
+
+    def __init__(self, api_key: str, model: str = "grok-4.20") -> None:
+        from openai import OpenAI
+
+        self._client = OpenAI(api_key=api_key, base_url="https://api.x.ai/v1")
+        self.model = model
+
+    def call(self, prompt: str, system_prompt: str = "You are a helpful assistant.") -> str:
+        """Send a prompt to Grok and return the model text response."""
+        completion = self._client.chat.completions.create(
+            model=self.model,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": prompt},
+            ],
+        )
+        return completion.choices[0].message.content or ""

--- a/annabanos/annaban/ledger.py
+++ b/annabanos/annaban/ledger.py
@@ -1,0 +1,35 @@
+"""JSONL governance ledger for auditability."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict
+
+
+class GovernanceLedger:
+    """Append-only JSONL log for governance decisions and model IO."""
+
+    def __init__(self, ledger_path: str = "logs/governance_ledger.jsonl") -> None:
+        self.ledger_path = Path(ledger_path)
+        self.ledger_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def append(
+        self,
+        prompt: str,
+        response: str,
+        risk_flagged: bool,
+        requires_approval: bool,
+    ) -> Dict[str, Any]:
+        """Append a single event to the JSONL ledger and return the event."""
+        event = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "prompt": prompt,
+            "response": response,
+            "risk_flagged": risk_flagged,
+            "requires_approval": requires_approval,
+        }
+        with self.ledger_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(event, ensure_ascii=False) + "\n")
+        return event

--- a/annabanos/annaban/tools.py
+++ b/annabanos/annaban/tools.py
@@ -1,0 +1,23 @@
+"""Simple dictionary-based tool registry for AnnabanOS."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict
+
+
+def verify_origin() -> str:
+    """Return a provenance string for the model backend."""
+    return "Grok via xAI API (https://api.x.ai/v1)"
+
+
+TOOL_REGISTRY: Dict[str, Callable[..., str]] = {
+    "verify_origin": verify_origin,
+}
+
+
+def call_tool(tool_name: str, **kwargs: Any) -> str:
+    """Execute a registered tool by name."""
+    tool = TOOL_REGISTRY.get(tool_name)
+    if tool is None:
+        raise ValueError(f"Unknown tool: {tool_name}")
+    return tool(**kwargs)

--- a/annabanos/docs/AnnabanAI_Whitepaper.md
+++ b/annabanos/docs/AnnabanAI_Whitepaper.md
@@ -1,0 +1,88 @@
+# AnnabanAI / AnnabanOS Whitepaper
+
+## 1. Abstract
+
+This document presents AnnabanOS, a prototype governance-first AI framework that integrates a large language model backend with policy enforcement, human approval controls, and auditable logging. The system is designed to demonstrate how operational safety mechanisms can be embedded at the application layer before potentially sensitive actions are allowed.
+
+## 2. Introduction
+
+Modern AI applications are increasingly used in contexts where generated guidance can influence real-world actions. In these environments, the reliability of outputs alone is insufficient; governance controls are required to ensure accountability, traceability, and human oversight. AnnabanOS addresses this need by combining model access with explicit policy gates and an immutable interaction trail.
+
+## 3. Problem Statement (AI Lacks Governance)
+
+Many AI integrations optimize for capability and latency but provide limited governance by default. Common gaps include:
+
+- No explicit policy enforcement at inference time
+- No mandatory human review for high-risk intents
+- Incomplete audit records for prompts and outputs
+- Limited separation of optimization objectives from safety objectives
+
+AnnabanOS is built as a practical response to these gaps, prioritizing governance as a first-class system requirement.
+
+## 4. System Architecture
+
+### 4.1 AnnabanOS
+
+AnnabanOS is the runtime framework that orchestrates model access, policy checks, tool invocation, and ledger logging. It serves as the execution boundary where governance decisions are made.
+
+### 4.2 AnnabanAI
+
+AnnabanAI refers to the application intelligence layer built on top of AnnabanOS. In this prototype, it includes the planner and oversight workflows powered by the Grok model through xAI's OpenAI-compatible API.
+
+### 4.3 AetherOS (Conceptual Oversight Layer)
+
+AetherOS is a conceptual supervisory layer representing higher-order governance and system-wide policy management. In this prototype, AetherOS is not implemented as a separate service; it is used as an architectural reference for future control-plane expansion.
+
+## 5. Governance Model
+
+### 5.1 Human-in-the-Loop (HITL)
+
+AnnabanOS enforces a human-approval requirement for high-risk intent classes. When prompts include terms associated with execution actions (for example, deploy or execute), the system blocks model execution and returns a mandatory approval notice requiring Jacob Kinnaird before proceeding.
+
+### 5.2 Policy Enforcement Points
+
+The primary policy enforcement point is the `AnnabanGovernance` wrapper. It intercepts every request, evaluates risk signals, and determines whether to:
+
+1. Block and request human approval, or
+2. Allow model invocation and return results
+
+All decisions are recorded in the governance ledger.
+
+## 6. Dual-Agent Design
+
+The prototype demonstrates two logical agents:
+
+- **Planner Agent (optimization)**: Generates efficient implementation or operational plans.
+- **Oversight Agent (safety/governance)**: Reviews plans for policy, control gaps, and risk mitigation.
+
+This separation clarifies competing objectives and supports governance-aware composition of AI behaviors.
+
+## 7. Life-Preservation Constraint
+
+AnnabanOS is designed under a conservative safety posture: generated guidance must not bypass human control for actions that may materially affect systems, operations, or people. This aligns with a life-preservation constraint where protection of human welfare and prevention of unsafe autonomy take precedence over automation speed.
+
+## 8. Auditability (Ledger Logging)
+
+AnnabanOS writes each interaction to an append-only JSONL ledger with:
+
+- Timestamp
+- Prompt
+- Response
+- Risk flag status
+- Approval requirement status
+
+This enables retrospective review, governance audits, and policy tuning based on observed usage patterns.
+
+## 9. Future Work
+
+Potential next steps include:
+
+- Role-based approval routing and multi-party signoff
+- Cryptographic ledger integrity checks
+- Expanded policy taxonomy beyond keyword matching
+- Policy simulation and red-team test harnesses
+- External SIEM and compliance pipeline integrations
+
+## 10. Conclusion
+
+AnnabanOS demonstrates a practical pattern for governance-first AI deployment using lightweight, transparent controls. By coupling model access with policy enforcement, human approval gates, and audit logging, the framework provides a foundation for safer, more accountable AI-assisted operations. As a prototype, it is intended for iterative hardening and extension rather than production-critical autonomy.

--- a/annabanos/examples/dual_agent_demo.py
+++ b/annabanos/examples/dual_agent_demo.py
@@ -1,0 +1,61 @@
+"""Dual-agent demo: planner + oversight with governance-first handling."""
+
+from __future__ import annotations
+
+import os
+
+from dotenv import load_dotenv
+
+from annaban.governance import AnnabanGovernance
+from annaban.grok_client import GrokClient
+from annaban.ledger import GovernanceLedger
+from annaban.tools import call_tool
+
+
+PLANNER_SYSTEM_PROMPT = (
+    "You are the Planner Agent. Produce efficient, step-by-step plans focused on optimization."
+)
+
+OVERSIGHT_SYSTEM_PROMPT = (
+    "You are the Oversight Agent. Review plans for safety, governance, and policy compliance."
+)
+
+
+def run_demo() -> None:
+    load_dotenv()
+    api_key = os.getenv("XAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("Missing XAI_API_KEY. Create a .env file from .env.example.")
+
+    origin = call_tool("verify_origin")
+    print(f"Tool output (verify_origin): {origin}\n")
+
+    client = GrokClient(api_key=api_key, model="grok-4.20")
+    ledger = GovernanceLedger(ledger_path="logs/governance_ledger.jsonl")
+    governance = AnnabanGovernance(grok_client=client, ledger=ledger)
+
+    task = "Design a migration plan for moving a legacy web service to a containerized platform."
+
+    planner_output = governance.process(
+        prompt=task,
+        system_prompt=PLANNER_SYSTEM_PROMPT,
+    )
+
+    oversight_prompt = (
+        "Review this planner output for governance and safety concerns. "
+        "Recommend controls and approval gates where needed.\n\n"
+        f"Planner output:\n{planner_output}"
+    )
+    oversight_output = governance.process(
+        prompt=oversight_prompt,
+        system_prompt=OVERSIGHT_SYSTEM_PROMPT,
+    )
+
+    print("=== Planner Agent Output ===")
+    print(planner_output)
+    print("\n=== Oversight Agent Output ===")
+    print(oversight_output)
+
+
+if __name__ == "__main__":
+    run_demo()

--- a/annabanos/main.py
+++ b/annabanos/main.py
@@ -1,0 +1,42 @@
+"""CLI entrypoint for AnnabanOS."""
+
+from __future__ import annotations
+
+import os
+
+from dotenv import load_dotenv
+
+from annaban.governance import AnnabanGovernance
+from annaban.grok_client import GrokClient
+from annaban.ledger import GovernanceLedger
+
+
+def build_governance() -> AnnabanGovernance:
+    load_dotenv()
+    api_key = os.getenv("XAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("Missing XAI_API_KEY. Create a .env file from .env.example.")
+
+    client = GrokClient(api_key=api_key, model="grok-4.20")
+    ledger = GovernanceLedger(ledger_path="logs/governance_ledger.jsonl")
+    return AnnabanGovernance(grok_client=client, ledger=ledger)
+
+
+def main() -> None:
+    governance = build_governance()
+    print("AnnabanOS CLI. Type 'exit' to quit.")
+
+    while True:
+        prompt = input("\nPrompt> ").strip()
+        if prompt.lower() in {"exit", "quit"}:
+            print("Goodbye.")
+            break
+        if not prompt:
+            continue
+
+        response = governance.process(prompt)
+        print(f"\nResponse:\n{response}")
+
+
+if __name__ == "__main__":
+    main()

--- a/annabanos/requirements.txt
+++ b/annabanos/requirements.txt
@@ -1,0 +1,2 @@
+openai>=1.0.0
+python-dotenv>=1.0.0


### PR DESCRIPTION
### Motivation

- Provide a small, runnable prototype that places governance first when calling the xAI Grok API (`https://api.x.ai/v1`) so high-risk intents are gated and auditable. 
- Demonstrate a minimal, production-style pattern for human-in-the-loop (HITL) approval, tool-calling, and dual-agent (Planner / Oversight) composition.

### Description

- Scaffold a complete repository layout under `annabanos/` with a CLI entrypoint (`main.py`), demo (`examples/dual_agent_demo.py`), and a formal whitepaper (`docs/AnnabanAI_Whitepaper.md`).
- Implement `GrokClient` in `annaban/grok_client.py` as a thin OpenAI-compatible wrapper configured for `base_url="https://api.x.ai/v1"` and default model `grok-4.20` with a `call(prompt, system_prompt)` method.
- Add `AnnabanGovernance` in `annaban/governance.py` which wraps the client, detects high-risk keywords (`deploy`, `execute`, `run`, `activate`), returns the approval gate message `⚠️ HUMAN APPROVAL REQUIRED FROM Jacob Kinnaird BEFORE EXECUTION` for flagged prompts, and delegates allowed prompts to the model.
- Provide an append-only JSONL ledger `GovernanceLedger` in `annaban/ledger.py` that records `timestamp`, `prompt`, `response`, `risk_flagged`, and `requires_approval`, and a simple tool registry with `verify_origin` and `call_tool` in `annaban/tools.py`.

### Testing

- Compiled the package tree with `python -m compileall .` in `annabanos/` which succeeded. 
- Ran an inline governance smoke test using a `DummyClient` and `GovernanceLedger` which demonstrated normal prompts are forwarded and high-risk prompts return the exact approval gate message and are logged. 
- Attempted to install dependencies with `pip install -r requirements.txt` but the install failed due to package index / proxy restrictions in the execution environment and not due to code errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c368b48c50832394684470e6351c5c)